### PR TITLE
Add nitpick to the fix aggregators list

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ https://github.com/rishirdua/awesome-code-formatters.
 ## Fix aggregators
 
 1. [**routine-update**](https://salsa.debian.org/science-team/routine-update) - run various codemods for Debian packages
+2. [**nitpick**](https://github.com/andreoliwa/nitpick) - Apply the same pre-defined settings across all your projects
 
 ## Commercial Platforms
 


### PR DESCRIPTION
Nitpick is a tool that takes style definitions for your project configuration files, such as `.editorconfig`, `.pre-commit`, `.eslint.json` and keeps them all up to date.

Disclaimer: I have contributed to the nitpick project as we use it to maintain coding standards tooling across a tech company's repositories. I am not a maintainer of the project.